### PR TITLE
fix(prepareLandoEnv): uncaught ENOTDIR error

### DIFF
--- a/vipdev.js
+++ b/vipdev.js
@@ -241,7 +241,21 @@ function updateClientCodeData( instanceData, codeParam ) {
 async function prepareLandoEnv( instanceData, instancePath ) {
 	if ( instanceData.clientcode.mode == 'git' && ! instanceData.clientcode.fetched ) {
 		const clonePath = instancePath + '/clientcode';
-		fs.rmdirSync(clonePath, { recursive: true });
+
+		try {
+			fs.rmdirSync(clonePath, { recursive: true })
+		} catch (err) {
+			const {
+				code = ''
+			} = err;
+
+			// rmdir throws an error if the directory does not exist.
+			// it's not worth wasting a call to fileExists beforehand since the goal is to delete the directory.
+			if ( -1 === ['ENOENT', 'ENOTDIR'].indexOf(code) ) {
+				// something else happened, throw the error.
+				throw err;
+			}
+		}
 
 		console.log( 'Cloning client code repo: ' + instanceData.clientcode.repo );
 


### PR DESCRIPTION
# Expected Behavior

1. Run create command
2. Create should complete without error.

```
./vipdev.js \
    create \
    clientenv \
    --title \"CLIENT\" \
    --php 7.3 \
    --wordpress 5.5.1 \
    --client-code \"$CLIENT_CODE_PATH\"
```

# What's actually occurring

When the create command is ran the first time, node throws a fatal error:

```
ENOENT: no such file or directory, rmdir '..'
```

# Patch suggested

From the docs:

> Using fs.rmdirSync() on a file (not a directory) results in an ENOENT error on Windows and an ENOTDIR error on POSIX.
>
> Setting recursive to true results in behavior similar to the Unix command rm -rf: an error will not be raised for paths that do not exist, and paths that represent files will be deleted. The permissive behavior of the recursive option is deprecated, ENOTDIR and ENOENT will be thrown in the future.
>
> - https://nodejs.org/api/fs.html#fs_fs_rmdirsync_path_options

Per this, I've added a try/catch block around the rmdirSync call and this allows the environment to create successfully.